### PR TITLE
Allow to capture completions and functions defined in the .zshrc

### DIFF
--- a/capture.zsh
+++ b/capture.zsh
@@ -3,10 +3,23 @@
 zmodload zsh/zpty || { echo 'error: missing module zsh/zpty' >&2; exit 1 }
 
 # spawn shell
-zpty z zsh -f -i
+zpty z zsh -i
 
 # line buffer for pty output
 local line
+
+# swallow input of zshrc, disable hooks and disable PROMPT
+# the prompt is disabled later as well but at least with powerlevel10k
+# it needs to be disabled twice.
+zpty -w z "autoload add-zsh-hook"
+zpty -w z "add-zsh-hook -D precmd '*'"
+zpty -w z "add-zsh-hook -D preexec '*'"
+zpty -w z "PROMPT="
+zpty -w z "echo thisisalonganduniquestringtomarktheendoftheinit >/dev/null"
+zpty -r z line
+while [[ $line != *'thisisalonganduniquestringtomarktheendoftheinit'* ]]; do
+    zpty -r z line
+done
 
 setopt rcquotes
 () {


### PR DESCRIPTION
I've tested this with the powerlevel10k prompt which needed some special handling.
Depending on the plugins loaded in the zshrc this might also have some unwanted side effects.