### PR TITLE
Use $ZDOTDIR instead of `~` if defined

### DIFF
--- a/capture.zsh
+++ b/capture.zsh
@@ -23,7 +23,7 @@ PROMPT=
 
 # load completion system
 autoload compinit
-compinit -d ~/.zcompdump_capture
+compinit -d "${ZDOTDIR:-~}/.zcompdump_capture"
 
 # never run a command
 bindkey ''^M'' undefined


### PR DESCRIPTION
Allows to keep `$HOME` directory clean, if [`$ZDOTDIR`](https://zsh.sourceforge.io/Intro/intro_3.html) is defined.

Use `~` as fallback if `$ZDOTDIR` not exists or empty